### PR TITLE
fix: パラメータが nullの場合に空文字を返すよう改修。（#55の対応）

### DIFF
--- a/app/utils/formatTime.ts
+++ b/app/utils/formatTime.ts
@@ -6,7 +6,9 @@ const formatTime = (timeString: string) => {
 };
 
 // 15分単位
-const formatTimeWithQuarter = (timeString: string) => {
+const formatTimeWithQuarter = (timeString: string | null) => {
+  if (!timeString) return "";
+
   const date = new Date(timeString);
   date.setMinutes(Math.ceil(date.getMinutes() / 15) * 15);
   return format(date, "HH:mm");


### PR DESCRIPTION
## 変更内容
・時刻フォーマット（※15分加算のケース）の際、パラメータが Nullの場合に空文字を返すよう改修。

## 関連する Issue
#55

## 変更理由
パラメータが Nullの場合、意図せず時刻がリターンされたため。
※詳細は #55 に掲載。

## スクリーンショット（UI の変更がある場合）
修正後、下図の通り施設利用中の履歴（＝end_time が Null）の場合に、該当欄がブランクとなる事を確認しました。
![image](https://github.com/user-attachments/assets/b87081c5-286e-4292-befa-ea8247b98f04)

## 動作確認

- [x] ローカル環境で動作確認済み
- [ ] ユニットテストが通過している　　　　　**←表示内容の変更のみのため、左記の対処は不要と判断**
- [ ] 必要に応じてドキュメントを更新した　　**←表示内容の変更のみのため、左記の対処は不要と判断**

## その他
ー