### PR TITLE
ユーザー検索ページに編集ボタン、NFC登録ボタンを設置

### DIFF
--- a/app/app/[locale]/(reception)/user-search/components/UserList.tsx
+++ b/app/app/[locale]/(reception)/user-search/components/UserList.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
-import { Tables } from "@/utils/supabase/database.types";
-
-type User = Tables<"users">;
+import { MdEdit, MdNfc } from "react-icons/md";
+import { User } from "@/types";
 
 type Props = {
   users: User[];
+  onEditClicked: (user: User) => void;
 };
 
-export default function UserList({ users }: Props) {
+export default function UserList({ users, onEditClicked }: Props) {
   return (
     <div className="mt-6">
       <h2 className="mb-4 text-xl font-bold">検索結果</h2>
@@ -25,12 +25,22 @@ export default function UserList({ users }: Props) {
                 <p className="text-gray-600">Email: {user.email}</p>
                 <p className="text-gray-500">電話番号: {user.phone}</p>
               </div>
-              <Link
-                className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
-                href={`/nfc-registration?userId=${user.id}`}
-              >
-                編集
-              </Link>
+              <div className="flex flex-col gap-2">
+                <button
+                  className="btn btn-sm btn-primary"
+                  onClick={() => onEditClicked(user)}
+                >
+                  <MdEdit size={20} />
+                  編集
+                </button>
+                <Link
+                  className="btn btn-sm btn-accent"
+                  href={`/nfc-registration?userId=${user.id}`}
+                >
+                  <MdNfc size={20} />
+                  NFC登録
+                </Link>
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## 変更内容
- ユーザー検索ページの検索結果の編集ボタンをユーザー編集フォームを表示するように修正
- 新たにNFC登録ボタンを追加し、NFC登録ページに遷移させるように修正した

## 関連する Issue

<!-- 関連するIssueがある場合はリンクを貼ってください -->

Closes #84 

## 変更理由

- ユーザー編集とNFC登録をそれぞれ可能にする

## スクリーンショット（UI の変更がある場合）

<img width="990" alt="スクリーンショット 2025-06-20 18 42 50" src="https://github.com/user-attachments/assets/8c821e7a-3f0e-46d4-806c-7f5bbc655af9" />


## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

