### PR TITLE
RLS設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ npx supabase gen types typescript --local > ./app/utils/supabase/database.types.
 npm run format:fix
 ```
 
+### supabase DB 　マイグレーション
+
+マイグレーションファイルの追加
+
+```
+npx supabase migration new add_xxx_xxx
+```
+
+マイグレーションを適用する
+
+```
+npx supabase migration up
+```
+
 ## ディレクトリの構成
 
 ```

--- a/supabase/migrations/20250621072828_add_admin_users_table.sql
+++ b/supabase/migrations/20250621072828_add_admin_users_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS admin_users (
+  id uuid primary key references auth.users(id),
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);

--- a/supabase/migrations/20250621073232_add_admin_policy.sql
+++ b/supabase/migrations/20250621073232_add_admin_policy.sql
@@ -1,0 +1,52 @@
+alter table admin_users enable row level security;
+
+-- 全ユーザーがadmin_usersテーブルにアクセスできないようにする
+CREATE POLICY "Public No access"
+ON admin_users
+FOR ALL
+TO public
+USING (false);
+
+-- 管理者ユーザーのみがadmin_usersテーブルにアクセスを許可する
+CREATE POLICY "Admin access for admin_users"
+ON admin_users
+FOR ALL
+TO authenticated
+USING (
+  auth.uid() IN (SELECT id FROM admin_users)
+);
+
+-- usersテーブルのRLSを有効にする
+alter table users enable row level security;
+
+-- 利用者登録対応のため、未認証でもINSERTを行えるようにする
+CREATE POLICY "Anyone can insert"
+ON users
+FOR INSERT
+TO public  -- public = 全ユーザー（認証なしでも可）
+WITH CHECK (true);
+
+-- 管理者ユーザーのみSELECT, UPDATE, DELETEを行えるようにする
+CREATE POLICY "Only admins can select"
+ON users
+FOR SELECT
+TO authenticated
+USING (
+  auth.uid() IN (SELECT id FROM admin_users)
+);
+
+CREATE POLICY "Only admins can update"
+ON users
+FOR UPDATE
+TO authenticated
+USING (
+  auth.uid() IN (SELECT id FROM admin_users)
+);
+
+CREATE POLICY "Only admins can delete"
+ON users
+FOR DELETE
+TO authenticated
+USING (
+  auth.uid() IN (SELECT id FROM admin_users)
+);


### PR DESCRIPTION
## 変更内容
- 管理者ユーザー用のadmin_usersテーブルを追加
- SupabaseのRLSをusersテーブルに適用

## 関連する Issue

Closes #90

## 変更理由

セキュリティ対応
- usersテーブルは個人情報が入るので、RLSを有効化
- コンソールから管理者の追加を想定して、admin_usersに管理者のUIDをもつホワイトリスト方式で制御

## スクリーンショット（UI の変更がある場合）


## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

Authenticationのapp_metadataに管理者フラグを追加する方法も検討したが、scriptで実行する必要があり煩雑なので、admin_usersテーブルで管理にした。

ひとまず、最低限の対応としてusersテーブルのみセキュリティを強化。利用履歴テーブルなど、必要があればRLSを有効化する。
