### PR TITLE
fix(app): 登録後にユーザーIDででエラーになる不具合の対応

### DIFF
--- a/app/app/[locale]/(registration)/registration/hooks/use-latest-registration-userid.ts
+++ b/app/app/[locale]/(registration)/registration/hooks/use-latest-registration-userid.ts
@@ -1,27 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery } from "@supabase-cache-helpers/postgrest-react-query";
 import supabase from "@/utils/supabase/client";
 
 export function useLatestRegistrationUserId() {
-  const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ["latest-registration-user-id"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("latest_registration_user_view")
-        .select("id")
-        .single();
-
-      if (error) {
-        throw error;
-      }
-
-      return data?.id;
-    },
-  });
+  const { data, isLoading, isError, refetch } = useQuery(
+    supabase.from("latest_registration_user_view").select("id").single(),
+  );
 
   return {
-    latestUserId: data,
+    latestUserId: data?.id,
     isLoading,
     isError,
-    refetch,
+    refetch: async () => {
+      const { data } = await refetch();
+      return { data: data?.data?.id };
+    },
   };
 }

--- a/app/app/[locale]/(registration)/registration/hooks/use-latest-registration-userid.ts
+++ b/app/app/[locale]/(registration)/registration/hooks/use-latest-registration-userid.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import supabase from "@/utils/supabase/client";
+
+export function useLatestRegistrationUserId() {
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ["latest-registration-user-id"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("latest_registration_user_view")
+        .select("id")
+        .single();
+
+      if (error) {
+        throw error;
+      }
+
+      return data?.id;
+    },
+  });
+
+  return {
+    latestUserId: data,
+    isLoading,
+    isError,
+    refetch,
+  };
+}

--- a/app/app/[locale]/(registration)/registration/hooks/use-submit-registration.ts
+++ b/app/app/[locale]/(registration)/registration/hooks/use-submit-registration.ts
@@ -9,14 +9,6 @@ export function useSubmitRegistration(options: {
   const { isPending, isError, isSuccess, mutateAsync } = useInsertMutation(
     supabase.from("users"),
     ["id"],
-    "id",
-    {
-      onSuccess: (data) => {
-        if (data) {
-          options.onSuccess(data[0].id);
-        }
-      },
-    },
   );
 
   return {

--- a/app/app/[locale]/(registration)/registration/page.tsx
+++ b/app/app/[locale]/(registration)/registration/page.tsx
@@ -16,6 +16,7 @@ import RegistrationConfirmation from "@/[locale]/(registration)/registration/com
 import RegistrationSteps from "@/[locale]/(registration)/registration/components/RegistrationSteps";
 import SurveyForm from "@/[locale]/(registration)/registration/components/SurveyForm";
 import { useAddressSearch } from "@/[locale]/(registration)/registration/hooks/use-address-search";
+import { useLatestRegistrationUserId } from "@/[locale]/(registration)/registration/hooks/use-latest-registration-userid";
 import { useSubmitRegistration } from "@/[locale]/(registration)/registration/hooks/use-submit-registration";
 import { registrationSchema } from "@/[locale]/(registration)/registration/schemas/registration-schema";
 import { RegistrationSchema } from "@/[locale]/(registration)/registration/types";
@@ -55,6 +56,7 @@ export default function Registration({
   });
   const { isPending: isAddressSearchPending, searchAddress } =
     useAddressSearch();
+  const { refetch: refetchLatestUserId } = useLatestRegistrationUserId();
 
   if (isRegistrationOptionsLoading) {
     return (
@@ -162,6 +164,12 @@ export default function Registration({
 
   const handleSubmit = async (data: RegistrationSchema) => {
     await insert(data);
+    const { data: latestUserId } = await refetchLatestUserId();
+
+    if (latestUserId) {
+      setCreatedUserId(latestUserId);
+      setCurrentStepIndex((prev) => prev + 1);
+    }
   };
 
   return (

--- a/app/app/utils/supabase/database.types.ts
+++ b/app/app/utils/supabase/database.types.ts
@@ -34,6 +34,24 @@ export type Database = {
   };
   public: {
     Tables: {
+      admin_users: {
+        Row: {
+          created_at: string | null;
+          id: string;
+          updated_at: string | null;
+        };
+        Insert: {
+          created_at?: string | null;
+          id: string;
+          updated_at?: string | null;
+        };
+        Update: {
+          created_at?: string | null;
+          id?: string;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       belong_translations: {
         Row: {
           belong_id: number;
@@ -617,6 +635,12 @@ export type Database = {
       };
     };
     Views: {
+      latest_registration_user_view: {
+        Row: {
+          id: number | null;
+        };
+        Relationships: [];
+      };
       seat_usage_daily_reports_view: {
         Row: {
           date: string | null;
@@ -673,7 +697,10 @@ export type Database = {
       };
     };
     Functions: {
-      [_ in never]: never;
+      get_latest_registration_user_id: {
+        Args: Record<PropertyKey, never>;
+        Returns: number;
+      };
     };
     Enums: {
       [_ in never]: never;

--- a/supabase/migrations/20250630121638_add_latest_registration_user_view.sql
+++ b/supabase/migrations/20250630121638_add_latest_registration_user_view.sql
@@ -1,0 +1,16 @@
+-- 利用者登録後のユーザーIDを取得するための関数とviewを作成
+-- RLSをバイパスするための関数を作成
+CREATE OR REPLACE FUNCTION public.get_latest_registration_user_id()
+RETURNS integer
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT id FROM users ORDER BY created_at DESC LIMIT 1;
+$$;
+
+-- 関数を未認証でも実行できるようにする
+GRANT EXECUTE ON FUNCTION public.get_latest_registration_user_id() TO public;
+
+-- 最後に登録したユーザーのidを取得するviewを作成
+CREATE VIEW public.latest_registration_user_view WITH (security_invoker=true) AS
+SELECT public.get_latest_registration_user_id() AS id;


### PR DESCRIPTION
## 変更内容
- 登録後にユーザーIDでエラーになる不具合の対応
- RLSをバイパスして最新のuserIdを返すlatest_registration_user_viewを追加

## 関連する Issue
なし

## 変更理由
- 登録後にユーザーID取得でのRLSエラーを修正

## スクリーンショット（UI の変更がある場合）

https://github.com/user-attachments/assets/30e966fd-be31-40ed-bfad-62d71de17099



## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

- usersテーブルのRLSは変更できないので、バイパス関数を作成しでlatest_registration_user_viewでuserIdを取得する実装にしている。
