### PR TITLE
fix(app): iPhone WalletのNFCカードで複数IDが読み取られ、それぞれにDB検索され、既にユーザーIDがある場合に空文字で上書きする処理を削除

### DIFF
--- a/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
@@ -15,6 +15,7 @@ interface ReceptionFormProps {
   emptySeats: Seat[];
   onChangeSearchWord: (input: string) => void;
   onClose: () => void;
+  onConnectUsbDevice: () => void;
   onDetectCard: (cardId: string) => void;
   onDisconnectUsbDevice: () => void;
   assignSeat: (seat: Seat, user: User) => void;
@@ -28,6 +29,7 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
   emptySeats,
   onChangeSearchWord,
   onClose,
+  onConnectUsbDevice,
   onDetectCard,
   onDisconnectUsbDevice,
   assignSeat,
@@ -83,6 +85,10 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
     setSelectedSeat(null);
     setIsConfirmModalOpen(false);
     onClose();
+  };
+
+  const handleConnectUsbDevice = () => {
+    onConnectUsbDevice();
   };
 
   const handleDetectCard = (cardId: string) => {
@@ -167,6 +173,7 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
         <div className="bg-base-200 w-2xl px-4 py-2">
           <div className="flex justify-between">
             <CardReaderControlButton
+              onConnectUsbDevice={handleConnectUsbDevice}
               onDetectCard={handleDetectCard}
               onDisconnectUsbDevice={handleDisconnectUsbDevice}
             />

--- a/app/app/[locale]/(reception)/home/page.tsx
+++ b/app/app/[locale]/(reception)/home/page.tsx
@@ -68,11 +68,14 @@ export default function HomePage() {
     error: updateUserError,
   } = useUpdateUser();
 
+  const handleConnectUsbDevice = () => {
+    setSearchUserKeyword("");
+  };
+
   const handleDetectCard = async (cardId: string) => {
     const userId = await searchNfc(cardId);
 
     if (userId === null) {
-      setSearchUserKeyword("");
       return;
     }
 
@@ -152,11 +155,12 @@ export default function HomePage() {
           emptySeats={seats.filter(
             (seat) => !seatUsages.some((usage) => usage.seatId === seat.id),
           )}
-          searchNfcError={searchNfcError}
+          searchNfcError={searchUserKeyword ? null : searchNfcError}
           searchUserList={users}
           searchWord={searchUserKeyword}
           onChangeSearchWord={handleChangeSearchWord}
-          onClose={() => {}}
+          onClose={() => clearSearchNfcError()}
+          onConnectUsbDevice={handleConnectUsbDevice}
           onDetectCard={handleDetectCard}
           onDisconnectUsbDevice={clearSearchNfcError}
           onEditUser={setEditUser}


### PR DESCRIPTION
## 変更内容

<!-- このPull Requestで何を変更したのか簡潔に説明してください -->

ホーム画面のユーザーID入力欄に既にユーザーIDがある場合に空文字で上書きする処理を削除

## 関連する Issue

<!-- 関連するIssueがある場合はリンクを貼ってください -->

Closes #93 

## 変更理由

<!-- なぜこの変更を行ったのか説明してください -->

ユーザーが既に見つかっているにも関わらず、空文字で上書きされてしまい、既に見つかったユーザーの選択が行いにくいため。

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

https://github.com/user-attachments/assets/1caf40cb-f6d9-4f0a-9344-5992c720f18b

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
下記のように、早期リターンしようとしたが、`handleDetectCard`が実行されるタイミングと`searchUserKeyword`が更新されるタイミングが合わないため断念。

```diff
const handleDetectCard = async (cardId: string) => {
+ if (searchUserKeyword) {
+   return;
+ }
+
  const userId = await searchNfc(cardId);

  if (userId === null) {
    return;
  }

  setSearchUserKeyword(userId.toString());
};
```
