### PR TITLE
feat(app): add non_japanese column to users

### DIFF
--- a/supabase/migrations/20250702084815_add_is_foreigner_to_users_table.sql
+++ b/supabase/migrations/20250702084815_add_is_foreigner_to_users_table.sql
@@ -1,0 +1,3 @@
+-- usersテーブルにis_non_japaneseカラムを追加
+ALTER TABLE public.users
+ADD COLUMN non_japanese BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## 変更内容
 usersテーブルにnon_japaneseカラムを追加
 
## 関連する Issue
なし

## 変更理由
- 海外の利用者の集計のため

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
