### PR TITLE
fix(app): fix useNfcDetectCard

### DIFF
--- a/app/app/hooks/use-nfc-detect-card.ts
+++ b/app/app/hooks/use-nfc-detect-card.ts
@@ -12,7 +12,7 @@ export function useNfcDetectCard({
   const [isPolling, setIsPolling] = useState(false);
   const detectCardIdPromiseRef = useRef<Promise<void> | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const nextRef = useRef<"A" | "F">("A");
+  const nextRef = useRef<"A" | "F">("F");
 
   const detectCardId = async () => {
     if (pollingRef.current) {
@@ -27,7 +27,9 @@ export function useNfcDetectCard({
       try {
         while (pollingRef.current) {
           const proto = nextRef.current;
-          nextRef.current = proto === "A" ? "F" : "A";
+          // iPhoneのときに、交互に読み取る不具合があるため暫定対応として無効にする
+          // nextRef.current = proto === "A" ? "F" : "A";
+
           const id = await nfcRef.current.detectCardId(proto);
 
           if (id) {


### PR DESCRIPTION

## 変更内容
NFC読み取りでiPhoneのときに、交互に読み取る不具合があるため暫定対応としてFタイプ(Felica)のみにする対応を行なう

## 関連する Issue

Closes #98

## 変更理由
iPhoneでの読み取りのときに交互に読み取られる不具合が、ポーリングの際にNFC Type AとType Fを切り替えているのが原因だった。
8桁と16桁のidが交互に読み取られるが、8桁をすると受付がうまくいかないため、ひとまずType F限定にして16桁のみにする。

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
