### PR TITLE
fix(app): update users table for non Japanese column

### DIFF
--- a/app/app/[locale]/(reception)/components/UserEditModal.tsx
+++ b/app/app/[locale]/(reception)/components/UserEditModal.tsx
@@ -20,6 +20,7 @@ const userFormSchema = z.object({
     .string()
     .min(1, { message: "電話番号を入力してください" })
     .regex(/^[0-9-]+$/, { message: "有効な電話番号を入力してください" }),
+  nonJapanese: z.boolean().optional(),
   prefectureId: z
     .string()
     .min(1, { message: "都道府県を選択してください" })
@@ -78,6 +79,7 @@ export const UserEditModal: React.FC<UserEditModalProps> = ({
       pronunciation: initialValues?.pronunciation,
       email: initialValues?.email,
       phone: initialValues?.phone,
+      nonJapanese: initialValues?.nonJapanese,
       prefectureId: initialValues?.prefectureId?.toString(),
       prefectureOther: initialValues?.prefectureOther,
       city: initialValues?.city,
@@ -94,6 +96,7 @@ export const UserEditModal: React.FC<UserEditModalProps> = ({
   });
 
   const submit = (data: UserFormData) => {
+    debugger;
     onSave(data);
     reset();
     onClose();
@@ -197,6 +200,26 @@ export const UserEditModal: React.FC<UserEditModalProps> = ({
                 <label className="label">
                   <span className="label-text-alt text-error">
                     {errors.phone.message}
+                  </span>
+                </label>
+              )}
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="form-control">
+              <input
+                className="checkbox"
+                type="checkbox"
+                {...register("nonJapanese")}
+              />
+              <label className="label">
+                <span className="label-text ml-2">外国人</span>
+              </label>
+
+              {errors.nonJapanese && (
+                <label className="label">
+                  <span className="label-text-alt text-error">
+                    {errors.nonJapanese.message}
                   </span>
                 </label>
               )}

--- a/app/app/[locale]/(reception)/hooks/use-update-user.ts
+++ b/app/app/[locale]/(reception)/hooks/use-update-user.ts
@@ -20,7 +20,7 @@ export const useUpdateUser = () => {
     try {
       setError(null);
       setIsLoading(true);
-
+      debugger;
       const { error } = await updateUser(userId, user);
       if (error) {
         setError(error);

--- a/app/app/[locale]/(reception)/queries/users-queries.ts
+++ b/app/app/[locale]/(reception)/queries/users-queries.ts
@@ -53,6 +53,7 @@ export const updateUser = (userId: number, user: Partial<User>) => {
     pronunciation: user.pronunciation,
     email: user.email,
     phone: user.phone,
+    non_japanese: user.nonJapanese,
     prefecture_id: user.prefectureId,
     prefecture_other: user.prefectureOther,
     city: user.city,

--- a/app/app/[locale]/(registration)/registration/hooks/use-submit-registration.ts
+++ b/app/app/[locale]/(registration)/registration/hooks/use-submit-registration.ts
@@ -1,5 +1,6 @@
 import { useInsertMutation } from "@supabase-cache-helpers/postgrest-react-query";
 import { RegistrationSchema } from "@/[locale]/(registration)/registration/types";
+import { STAY_CATEGORY_DEFAULT_VALUE_ID } from "@/constants/stay-category";
 import supabase from "@/utils/supabase/client";
 import { Database } from "@/utils/supabase/database.types";
 
@@ -32,7 +33,9 @@ function transformRegistrationValues(
     email: contact.email,
     phone: contact.phone,
     prefecture_id: Number(nameAddress.prefectureId),
-    stay_category_id: Number(nameAddress.stayCategoryId),
+    stay_category_id: Number(nameAddress.stayCategoryId), // TODO non_japaneseと被っているので整理する
+    non_japanese:
+      Number(nameAddress.stayCategoryId) !== STAY_CATEGORY_DEFAULT_VALUE_ID, // 外国人かどうかのフラグ
     prefecture_other: nameAddress.prefectureOther,
     city: nameAddress.city,
     address: nameAddress.address,

--- a/app/app/types/user.d.ts
+++ b/app/app/types/user.d.ts
@@ -4,6 +4,7 @@ export type User = {
   pronunciation: string;
   email: string;
   phone: string;
+  nonJapanese: boolean;
   prefectureId: number;
   prefectureOther: string;
   city: string;

--- a/app/app/utils/supabase/database.types.ts
+++ b/app/app/utils/supabase/database.types.ts
@@ -537,6 +537,7 @@ export type Database = {
           job_id: number | null;
           job_other: string | null;
           name: string | null;
+          non_japanese: boolean | null;
           phone: string | null;
           prefecture_id: number | null;
           prefecture_other: string | null;
@@ -562,6 +563,7 @@ export type Database = {
           job_id?: number | null;
           job_other?: string | null;
           name?: string | null;
+          non_japanese?: boolean | null;
           phone?: string | null;
           prefecture_id?: number | null;
           prefecture_other?: string | null;
@@ -587,6 +589,7 @@ export type Database = {
           job_id?: number | null;
           job_other?: string | null;
           name?: string | null;
+          non_japanese?: boolean | null;
           phone?: string | null;
           prefecture_id?: number | null;
           prefecture_other?: string | null;


### PR DESCRIPTION
## 変更内容
利用者登録および編集でnon_japaneseフラグを追加

## 関連する Issue
Closes #108

## 変更理由
既存の利用者の外国人判定を手動で、non_japaneseカラムに追加したので新規利用者も対応する

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
