### PR TITLE
席延長の時間を前の終了時間にする

### DIFF
--- a/app/app/[locale]/(reception)/home/client-components/InUseSeatModal.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/InUseSeatModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { addHours } from "date-fns";
 import React, { useState } from "react";
 import { Seat, SeatUsage } from "@/types";
 import { ExtendSeatConfirmModalBox } from "./ExtendSeatConfirmModalBox";
@@ -81,7 +82,7 @@ export const InUseSeatModal: React.FC<InUseSeatModalProps> = ({
   const handleExtendSeatClicked = () => {
     setNextSeatUsage({
       ...seatUsage,
-      startTime: new Date().toISOString(),
+      startTime: addHours(new Date(seatUsage.startTime), 2).toISOString(),
       endTime: null,
     });
     setModalType("extendConfirm");

--- a/app/app/[locale]/(reception)/home/client-components/SeatCard.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/SeatCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React from "react";
-import ClockIcon from "@/components/icons/ClockIcon";
+import { MdAccessAlarm } from "react-icons/md";
+import { MdAccessTime } from "react-icons/md";
 import SeatIcon from "@/components/icons/SeatIcon";
 import UserIcon from "@/components/icons/UserIcon";
 import { Seat, SeatUsage } from "@/types";
@@ -18,6 +19,12 @@ const SeatCard: React.FC<SeatProps> = ({
   seatUsage = null,
   onSeatClick,
 }) => {
+  const endTime = seatUsage?.startTime
+    ? addHours(seatUsage.startTime, 2)
+    : null;
+
+  const isOver = endTime ? new Date(endTime) < new Date() : false;
+
   return (
     <div
       className={`card card-xs card-border ${seatUsage?.userId ? "border-accent bg-accent/30" : "border-primary"} h-[8rem] w-[7rem] cursor-pointer`}
@@ -37,9 +44,16 @@ const SeatCard: React.FC<SeatProps> = ({
               <UserIcon />
               <div className="text-base">{seatUsage.userId}</div>
             </div>
-            <div className="flex flex-row items-center gap-[0.125rem]">
-              <ClockIcon />
-              <div className="text-xs">
+            <div
+              className={`flex flex-row items-center gap-[0.125rem] ${isOver ? "text-error" : ""}`}
+            >
+              {isOver ? (
+                <MdAccessAlarm className="text-error text-base" />
+              ) : (
+                <MdAccessTime className="text-base" />
+              )}
+
+              <div className="ml-0.5 text-xs">
                 {`${formatTimeWithQuarter(seatUsage.startTime)} - ${formatTimeWithQuarter(addHours(seatUsage.startTime, 2))}`}
               </div>
             </div>

--- a/app/app/[locale]/(reception)/hooks/use-seat-usage.test.ts
+++ b/app/app/[locale]/(reception)/hooks/use-seat-usage.test.ts
@@ -103,7 +103,7 @@ describe("useSeatUsage", () => {
           1,
           expect.any(String),
         );
-        expect(createSeatUsage).toHaveBeenCalledWith(1, 1);
+        expect(createSeatUsage).toHaveBeenCalledWith(1, 1, expect.any(String));
       });
     });
 

--- a/app/app/[locale]/(reception)/hooks/use-seat-usage.ts
+++ b/app/app/[locale]/(reception)/hooks/use-seat-usage.ts
@@ -61,7 +61,11 @@ export const useSeatUsage = () => {
       return;
     }
     const { data: nextSeatUsageData, error: createNextSeatUsageError } =
-      await createSeatUsage(seatUsage.seatId, seatUsage.userId);
+      await createSeatUsage(
+        seatUsage.seatId,
+        seatUsage.userId,
+        new Date(seatUsage.startTime).toISOString(),
+      );
     if (createNextSeatUsageError) {
       setError(createNextSeatUsageError);
       setIsLoading(false);


### PR DESCRIPTION
## 変更内容
- 座席延長が延長ボタンをタップしたときからになっているので、前の終了時間から2時間というように変更した
- 利用時間超過時のUIを変更（時間を赤字に変更）

## 関連する Issue

Closes #107

## 変更理由

これまでの延長方法と集計方法に合わせるため

## スクリーンショット（UI の変更がある場合）


## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
