### PR TITLE
レポートページの海外利用者の集計方法を変更

### DIFF
--- a/supabase/migrations/20250708001432_update_report_views.sql
+++ b/supabase/migrations/20250708001432_update_report_views.sql
@@ -1,0 +1,91 @@
+
+CREATE OR REPLACE VIEW public.seat_usage_daily_reports_view with(security_invoker=true) AS
+  SELECT
+    DATE(usages.created_at) AS date,
+
+    COUNT(users.id) AS total_users, -- 全ての延べ利用数
+    COUNT(DISTINCT users.id) AS unique_users, -- ユニークなユーザー数
+
+    COUNT(CASE WHEN users.non_japanese = true THEN 1 END) AS total_overseas_users, -- 海外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.non_japanese = true THEN users.id END) AS unique_overseas_users, -- 海外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id NOT IN (99, 40) THEN 1 END) AS total_outside_fukuoka_pref_users, -- 福岡県外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id NOT IN (99, 40) THEN users.id END) AS unique_outside_fukuoka_pref_users, -- 福岡県外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 THEN 1 END) AS total_fukuoka_pref_users, -- 福岡県ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 THEN users.id END) AS unique_fukuoka_pref_users, -- 福岡県ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 AND users.city NOT LIKE '%福岡市%' THEN 1 END) AS total_outside_fukuoka_city_users, -- 福岡市外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 AND users.city NOT LIKE '%福岡市%' THEN users.id END) AS unique_outside_fukuoka_city_users, -- 福岡市外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 AND users.city LIKE '%福岡市%' THEN 1 END) AS total_fukuoka_city_users, -- 福岡市ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 AND users.city LIKE '%福岡市%' THEN users.id END) AS unique_fukuoka_city_users -- 福岡市ユーザーのユニーク数
+  FROM
+    seat_usage_logs AS usages
+  JOIN
+    users ON usages.user_id = users.id
+  WHERE
+    usages.is_delete IS NULL OR usages.is_delete = FALSE
+  GROUP BY
+    DATE(usages.created_at);
+
+
+CREATE OR REPLACE VIEW public.seat_usage_monthly_reports_view with(security_invoker=true) AS
+  SELECT
+    TO_CHAR(DATE_TRUNC('month', usages.created_at), 'YYYY-MM') AS month,
+
+    COUNT(users.id) AS total_users, -- 全ての延べ利用数
+    COUNT(DISTINCT users.id) AS unique_users, -- ユニークなユーザー数
+
+    COUNT(CASE WHEN users.non_japanese = true THEN 1 END) AS total_overseas_users, -- 海外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.non_japanese = true THEN users.id END) AS unique_overseas_users, -- 海外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id NOT IN (99, 40) THEN 1 END) AS total_outside_fukuoka_pref_users, -- 福岡県外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id NOT IN (99, 40) THEN users.id END) AS unique_outside_fukuoka_pref_users, -- 福岡県外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 THEN 1 END) AS total_fukuoka_pref_users, -- 福岡県ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 THEN users.id END) AS unique_fukuoka_pref_users, -- 福岡県ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 AND users.city NOT LIKE '%福岡市%' THEN 1 END) AS total_outside_fukuoka_city_users, -- 福岡市外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 AND users.city NOT LIKE '%福岡市%' THEN users.id END) AS unique_outside_fukuoka_city_users, -- 福岡市外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 AND users.city LIKE '%福岡市%' THEN 1 END) AS total_fukuoka_city_users, -- 福岡市ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 AND users.city LIKE '%福岡市%' THEN users.id END) AS unique_fukuoka_city_users -- 福岡市ユーザーのユニーク数
+  FROM
+    seat_usage_logs AS usages
+  JOIN
+    users ON usages.user_id = users.id
+  WHERE
+    usages.is_delete IS NULL OR usages.is_delete = FALSE
+  GROUP BY
+    DATE_TRUNC('month', usages.created_at);
+
+CREATE OR REPLACE VIEW public.seat_usage_yearly_reports_view with(security_invoker=true) AS
+  SELECT
+    TO_CHAR(DATE_TRUNC('year', usages.created_at), 'YYYY') AS year,
+
+    COUNT(users.id) AS total_users, -- 全ての延べ利用数
+    COUNT(DISTINCT users.id) AS unique_users, -- ユニークなユーザー数
+
+    COUNT(CASE WHEN users.non_japanese = true THEN 1 END) AS total_overseas_users, -- 海外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.non_japanese = true THEN users.id END) AS unique_overseas_users, -- 海外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id NOT IN (99, 40) THEN 1 END) AS total_outside_fukuoka_pref_users, -- 福岡県外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id NOT IN (99, 40) THEN users.id END) AS unique_outside_fukuoka_pref_users, -- 福岡県外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 THEN 1 END) AS total_fukuoka_pref_users, -- 福岡県ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 THEN users.id END) AS unique_fukuoka_pref_users, -- 福岡県ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 AND users.city NOT LIKE '%福岡市%' THEN 1 END) AS total_outside_fukuoka_city_users, -- 福岡市外ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 AND users.city NOT LIKE '%福岡市%' THEN users.id END) AS unique_outside_fukuoka_city_users, -- 福岡市外ユーザーのユニーク数
+
+    COUNT(CASE WHEN users.prefecture_id = 40 AND users.city LIKE '%福岡市%' THEN 1 END) AS total_fukuoka_city_users, -- 福岡市ユーザーの延べ利用数
+    COUNT(DISTINCT CASE WHEN users.prefecture_id = 40 AND users.city LIKE '%福岡市%' THEN users.id END) AS unique_fukuoka_city_users -- 福岡市ユーザーのユニーク数
+  FROM
+    seat_usage_logs AS usages
+  JOIN
+    users ON usages.user_id = users.id
+  WHERE
+    usages.is_delete IS NULL OR usages.is_delete = FALSE
+  GROUP BY
+    DATE_TRUNC('year', usages.created_at);

--- a/supabase/migrations/20250708002151_add_rls_policies.sql
+++ b/supabase/migrations/20250708002151_add_rls_policies.sql
@@ -1,0 +1,8 @@
+-- old_usersテーブルのRLSを有効にする(コンソールonly)
+alter table old_users enable row level security;
+
+-- old_nfcsテーブルのRLSを有効にする(コンソールonly)
+alter table old_nfcs enable row level security;
+
+-- old_logsテーブルのRLSを有効にする(コンソールonly)
+alter table old_logs enable row level security;

--- a/supabase/migrations/20250708003755_add_seat_usage_logs_rls_policies.sql
+++ b/supabase/migrations/20250708003755_add_seat_usage_logs_rls_policies.sql
@@ -1,0 +1,11 @@
+-- seat_usage_logsテーブルのRLSを有効にする
+alter table seat_usage_logs enable row level security;
+
+-- 管理者ユーザーのみがseat_usage_logsテーブルにアクセスを許可する
+CREATE POLICY "Admin access for seat_usage_logs"
+ON seat_usage_logs
+FOR ALL
+TO authenticated
+USING (
+  auth.uid() IN (SELECT id FROM admin_users)
+);


### PR DESCRIPTION
## 変更内容
レポートページの海外の集計方法をprefacture_idから、non_japaneseフラグを使うように変更した

## 関連する Issue

Closes #111

## 変更理由
集計方法変更に対応するため

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
