### PR TITLE
受付の会員番号を入館処理が終わるまで保持する

### DIFF
--- a/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
@@ -298,7 +298,12 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
                 </div>
               </div>
               <div className="flex justify-around">
-                <button className="btn btn-secondary" onClick={handleClose}>
+                <button
+                  className="btn btn-secondary"
+                  onClick={() => {
+                    setSelectedUser(null);
+                  }}
+                >
                   閉じる
                 </button>
                 <button
@@ -324,12 +329,6 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
           onAssignSeat={handleAssignSeat}
           onClose={() => setIsConfirmModalOpen(false)}
         />
-      )}
-      {searchUserList && searchUserList.length > 0 && selectedUser === null && (
-        <div
-          className="modal-backdrop fixed inset-0 z-[1] h-screen w-screen"
-          onClick={handleClose}
-        ></div>
       )}
     </>
   );


### PR DESCRIPTION
## 変更内容
受付の会員番号を入館処理が終わるまで保持するように変更
入館処理が完了するか、会員番号フォームのxボタンでクリアする

## 関連する Issue

Closes #119

## 変更理由
受付業務でのフィードバックを反映

## スクリーンショット（UI の変更がある場合）

https://github.com/user-attachments/assets/2c76deae-795a-4053-8725-69d8df6e207d

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
