### PR TITLE
feat(app): 新規会員登録画面の言語切替機能を追加

### DIFF
--- a/app/app/[locale]/(registration)/registration/components/ConsentForm.tsx
+++ b/app/app/[locale]/(registration)/registration/components/ConsentForm.tsx
@@ -4,6 +4,7 @@ import { Locale, useLocale, useTranslations } from "next-intl";
 import { ComponentType } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { RegistrationSchema } from "@/[locale]/(registration)/registration/types";
+import LocaleSwitcher from "@/components/LocaleSwitcher";
 import type { MDXProps } from "mdx/types";
 
 type ConsentFormProps = {
@@ -34,7 +35,10 @@ export default function ConsentForm({ methods }: ConsentFormProps) {
         {t("title")}
       </h1>
       <p className="text-center text-xl text-gray-400">{t("subTitle")}</p>
-      <div className="bg-base-100 border-base-300 my-6 rounded-lg border p-4">
+      <div className="mx-auto my-1 w-fit">
+        <LocaleSwitcher />
+      </div>
+      <div className="bg-base-100 border-base-300 my-2 rounded-lg border p-4">
         <div className="h-96 overflow-auto">
           <article className="prose prose-sm prose-h1:text-xl prose-h2:text-lg prose-h3:text-base">
             <RegistrationTerms />

--- a/app/app/components/LocaleSwitcher.tsx
+++ b/app/app/components/LocaleSwitcher.tsx
@@ -1,0 +1,18 @@
+import { useLocale, useTranslations } from "next-intl";
+import LocaleSwitcherSelect from "@/components/LocaleSwitcherSelect";
+import { routing } from "~/i18n/routing";
+
+export default function LocaleSwitcher() {
+  const t = useTranslations("LocaleSwitcher");
+  const locale = useLocale();
+
+  return (
+    <LocaleSwitcherSelect defaultValue={locale}>
+      {routing.locales.map((cur) => (
+        <option key={cur} value={cur}>
+          {t("locale", { locale: cur })}
+        </option>
+      ))}
+    </LocaleSwitcherSelect>
+  );
+}

--- a/app/app/components/LocaleSwitcherSelect.tsx
+++ b/app/app/components/LocaleSwitcherSelect.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { Locale } from "next-intl";
+import { ChangeEvent, ReactNode, useTransition } from "react";
+import { usePathname, useRouter } from "~/i18n/navigation";
+
+type LocaleSwitcherSelectProps = {
+  children: ReactNode;
+  defaultValue: Locale;
+};
+
+export default function LocaleSwitcherSelect({
+  children,
+  defaultValue,
+}: LocaleSwitcherSelectProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const pathname = usePathname();
+  const params = useParams();
+
+  const handleSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextLocale = event.target.value as Locale;
+
+    startTransition(() => {
+      router.replace({ pathname, query: params }, { locale: nextLocale });
+    });
+  };
+
+  return (
+    <select
+      className="select select-ghost select-xs"
+      defaultValue={defaultValue}
+      disabled={isPending}
+      onChange={handleSelectChange}
+    >
+      {children}
+    </select>
+  );
+}

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1,4 +1,7 @@
 {
+  "LocaleSwitcher": {
+    "locale": "{locale, select, ja {日本語} en {English} other {Unknown}}"
+  },
   "MultiStepForm": {
     "back": "Back",
     "next": "Next",

--- a/app/messages/ja.json
+++ b/app/messages/ja.json
@@ -1,4 +1,7 @@
 {
+  "LocaleSwitcher": {
+    "locale": "{locale, select, ja {日本語} en {English} other {不明}}"
+  },
   "MultiStepForm": {
     "back": "前へ",
     "next": "次へ",


### PR DESCRIPTION
## 変更内容

<!-- このPull Requestで何を変更したのか簡潔に説明してください -->

新規会員登録画面のトップページに言語選択を追加した。

## 関連する Issue

<!-- 関連するIssueがある場合はリンクを貼ってください -->

Closes #126 

## 変更理由

<!-- なぜこの変更を行ったのか説明してください -->

ユーザーが言語切替できるようにするため。

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

![registration_ja](https://github.com/user-attachments/assets/e6df860a-6ae1-4da3-bed0-7e218e6b905b)
![registration_en](https://github.com/user-attachments/assets/a7f1f5b6-3464-4751-9384-b81f180e1ccb)

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->

新規会員登録の途中のフォームで言語を切り替えてしまった場合、最初の画面（利用規約同意フォーム）に戻ってしまうため、最初の画面でのみ言語を切り替えられるようにした。
