### PR TITLE
受付フォームの検索結果をローディング中は空にする

### DIFF
--- a/app/app/[locale]/(reception)/home/page.tsx
+++ b/app/app/[locale]/(reception)/home/page.tsx
@@ -160,7 +160,7 @@ export default function HomePage() {
             (seat) => !seatUsages.some((usage) => usage.seatId === seat.id),
           )}
           searchNfcError={searchUserKeyword ? null : searchNfcError}
-          searchUserList={users}
+          searchUserList={isLoading ? [] : users}
           searchWord={searchUserKeyword}
           onChangeSearchWord={handleChangeSearchWord}
           onClose={() => clearSearchNfcError()}


### PR DESCRIPTION
## 変更内容
受付フォームの検索結果をローディング中は空にする

## 関連する Issue

Closes #116 

## 変更理由

番号が前方一致すると別のユーザーを表示してしまうことへの対応

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
