### PR TITLE
受付フォームの検索結果を番号が変わるたびに空にする

### DIFF
--- a/app/app/[locale]/(reception)/home/page.tsx
+++ b/app/app/[locale]/(reception)/home/page.tsx
@@ -47,6 +47,7 @@ export default function HomePage() {
     isLoading: usersLoading,
     error: usersError,
     fetch: fetchUsers,
+    clear: clearSearchUsers,
   } = useSearchUsers(debouncedChangeSearchWord);
   const {
     search: searchNfc,
@@ -83,6 +84,7 @@ export default function HomePage() {
   };
 
   const handleChangeSearchWord = (searchWord: string) => {
+    clearSearchUsers();
     setSearchUserKeyword(searchWord);
   };
 
@@ -160,7 +162,7 @@ export default function HomePage() {
             (seat) => !seatUsages.some((usage) => usage.seatId === seat.id),
           )}
           searchNfcError={searchUserKeyword ? null : searchNfcError}
-          searchUserList={isLoading ? [] : users}
+          searchUserList={users}
           searchWord={searchUserKeyword}
           onChangeSearchWord={handleChangeSearchWord}
           onClose={() => clearSearchNfcError()}

--- a/app/app/[locale]/(reception)/hooks/use-search-users.ts
+++ b/app/app/[locale]/(reception)/hooks/use-search-users.ts
@@ -46,5 +46,11 @@ export const useSearchUsers = (keyword?: string) => {
     setIsLoading(false);
   };
 
-  return { users, isLoading, error, fetch };
+  const clear = () => {
+    setUsers([]);
+    setError(null);
+    setIsLoading(false);
+  };
+
+  return { users, isLoading, error, fetch, clear };
 };


### PR DESCRIPTION
## 変更内容

受付フォームの検索結果を番号が変わるたびに空にする

## 関連する Issue

Closes #116

## 変更理由

ローディング中は空の対応では不十分だったので、強制的に空にする処理を追加した

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
