### PR TITLE
feat(app): add order control of seat categories to reception form

### DIFF
--- a/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
@@ -47,16 +47,17 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
     setSelectedUser(user);
   };
 
-  const areaList = React.useMemo(
-    () =>
-      emptySeats
-        .map((seat: Seat) => seat.seatCategory.name)
-        .filter(
-          (categoryName: string, index: number, self: string[]) =>
-            self.indexOf(categoryName) === index,
-        ),
-    [emptySeats],
-  );
+  const areaList = React.useMemo(() => {
+    const categories = emptySeats.map((seat: Seat) => seat.seatCategory);
+
+    return categories
+      .sort((a, b) => a.order - b.order)
+      .map((category) => category.name)
+      .filter(
+        (categoryName: string, index: number, self: string[]) =>
+          self.indexOf(categoryName) === index,
+      );
+  }, [emptySeats]);
 
   const seatList = (categoryName: string) =>
     emptySeats.filter((seat: Seat) => seat.seatCategory.name === categoryName);

--- a/supabase/migrations/20250712060149_add_order_to_seat_categories.sql
+++ b/supabase/migrations/20250712060149_add_order_to_seat_categories.sql
@@ -1,0 +1,3 @@
+-- Add order column to seat_categories table
+ALTER TABLE public.seat_categories
+ADD COLUMN "order" INTEGER DEFAULT 9999;


### PR DESCRIPTION
## 変更内容

受付フォームのエリアの表示順を変更できるようにした

## 関連する Issue

Closes #128

## 変更理由

受付からのリクエスト

## スクリーンショット（UI の変更がある場合）
<img width="534" height="569" alt="スクリーンショット 2025-07-12 16 15 17" src="https://github.com/user-attachments/assets/43d8d15f-3c62-4b42-bc46-7016be5c554c" />


## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

- 順番は、seat_categoriesテーブルのorderカラムにsupabaseのコンソールから変更する
