### PR TITLE
会員番号を速く入力すると検索結果が表示されなくなる不具合を修正

### DIFF
--- a/app/app/[locale]/(reception)/home/page.tsx
+++ b/app/app/[locale]/(reception)/home/page.tsx
@@ -84,7 +84,6 @@ export default function HomePage() {
   };
 
   const handleChangeSearchWord = (searchWord: string) => {
-    clearSearchUsers();
     setSearchUserKeyword(searchWord);
   };
 


### PR DESCRIPTION
## 変更内容

会員番号を速く入力すると検索結果が表示されなくなる不具合を修正

## 関連する Issue
#106?

Closes #

## 変更理由

フォームにデバウンスの設定しているが、検索結果のクリアをフォーム変更時に行なっていたため、デバウンス設定以下のタイミングで番号入力すると結果が表示されない現象があった。

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

#106 の直接の原因かは不明。
