### PR TITLE
ユーザー編集フォームから削除（論理削除）を可能にした

### DIFF
--- a/app/app/[locale]/(reception)/components/UserEditModal.tsx
+++ b/app/app/[locale]/(reception)/components/UserEditModal.tsx
@@ -50,6 +50,7 @@ interface UserEditModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (userData: UserFormData) => void;
+  onDelete: (userId: number) => void;
   initialValues?: Partial<User>;
   prefectures: Prefecture[];
   belongs: Belong[];
@@ -60,6 +61,7 @@ export const UserEditModal: React.FC<UserEditModalProps> = ({
   isOpen,
   onClose,
   onSave,
+  onDelete,
   initialValues,
   prefectures,
   belongs,
@@ -96,10 +98,21 @@ export const UserEditModal: React.FC<UserEditModalProps> = ({
   });
 
   const submit = (data: UserFormData) => {
-    debugger;
     onSave(data);
     reset();
     onClose();
+  };
+
+  const handleDelete = () => {
+    if (initialValues?.id) {
+      const confirmed = confirm("本当に削除しますか？");
+      if (!confirmed) {
+        return;
+      }
+      onDelete(initialValues?.id);
+      reset();
+      onClose();
+    }
   };
 
   return (
@@ -424,20 +437,31 @@ export const UserEditModal: React.FC<UserEditModalProps> = ({
             />
           </div>
 
-          <div className="modal-action">
-            <button
-              className="btn"
-              type="button"
-              onClick={() => {
-                reset();
-                onClose();
-              }}
-            >
-              閉じる
-            </button>
-            <button className="btn btn-primary" type="submit">
-              保存
-            </button>
+          <div className="modal-action justify-between">
+            <div>
+              <button
+                className="btn btn-error text-white"
+                type="button"
+                onClick={handleDelete}
+              >
+                削除
+              </button>
+            </div>
+            <div className="flex gap-4">
+              <button
+                className="btn"
+                type="button"
+                onClick={() => {
+                  reset();
+                  onClose();
+                }}
+              >
+                閉じる
+              </button>
+              <button className="btn btn-primary" type="submit">
+                保存
+              </button>
+            </div>
           </div>
         </form>
       </div>

--- a/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
@@ -13,6 +13,8 @@ interface ReceptionFormProps {
   searchUserList: User[] | null;
   searchNfcError: string | null;
   emptySeats: Seat[];
+  selectedUser: User | null;
+  onSelectUser: (user: User) => void;
   onChangeSearchWord: (input: string) => void;
   onClose: () => void;
   onConnectUsbDevice: () => void;
@@ -27,6 +29,8 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
   searchUserList,
   searchNfcError,
   emptySeats,
+  selectedUser,
+  onSelectUser,
   onChangeSearchWord,
   onClose,
   onConnectUsbDevice,
@@ -39,12 +43,10 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
   const [selectedArea, setSelectedArea] = useState<string | null>(null);
   const [selectedSeat, setSelectedSeat] = useState<Seat | null>(null);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
-  const [selectedUser, setSelectedUser] = useState<User | null>(null);
-
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleSelectUser = (user: User) => {
-    setSelectedUser(user);
+    onSelectUser(user);
   };
 
   const areaList = React.useMemo(() => {
@@ -85,7 +87,6 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
   const handleClose = () => {
     handleChangeSearchWord("");
     setSelectedUserIndex(0);
-    setSelectedUser(null);
     setSelectedArea(null);
     setSelectedSeat(null);
     setIsConfirmModalOpen(false);
@@ -121,10 +122,10 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
       ) {
         setIsConfirmModalOpen(true);
       } else if (searchUserList && selectedUser === null) {
-        setSelectedUser(searchUserList[selectedUserIndex]);
+        onSelectUser(searchUserList[selectedUserIndex]);
       }
     },
-    [selectedUser, selectedUserIndex, searchUserList],
+    [selectedUser, searchUserList, onSelectUser, selectedUserIndex],
   );
 
   const handleArrowDownKeyDown = useCallback(
@@ -308,12 +309,7 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
                 </div>
               </div>
               <div className="flex justify-around">
-                <button
-                  className="btn btn-secondary"
-                  onClick={() => {
-                    setSelectedUser(null);
-                  }}
-                >
+                <button className="btn btn-secondary" onClick={handleClose}>
                   閉じる
                 </button>
                 <button

--- a/app/app/[locale]/(reception)/hooks/use-soft-delete-user.ts
+++ b/app/app/[locale]/(reception)/hooks/use-soft-delete-user.ts
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { softDeleteUser as deleteUserQuery } from "@/[locale]/(reception)/queries/users-queries";
+
+export const useSoftDeleteUser = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // ユーザーを更新する
+  //@param userId ユーザーID
+  //@returns 更新後のユーザーデータ
+  const softDeleteUser = async (userId: number): Promise<void> => {
+    try {
+      setError(null);
+      setIsLoading(true);
+
+      const { error } = await deleteUserQuery(userId);
+      if (error) {
+        setError(error);
+        setIsLoading(false);
+        return;
+      }
+    } catch (error) {
+      setError(error as Error);
+      return;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    softDeleteUser,
+    isLoading,
+    error,
+  };
+};

--- a/app/app/[locale]/(reception)/hooks/use-update-user.ts
+++ b/app/app/[locale]/(reception)/hooks/use-update-user.ts
@@ -20,7 +20,7 @@ export const useUpdateUser = () => {
     try {
       setError(null);
       setIsLoading(true);
-      debugger;
+
       const { error } = await updateUser(userId, user);
       if (error) {
         setError(error);

--- a/app/app/[locale]/(reception)/queries/users-queries.ts
+++ b/app/app/[locale]/(reception)/queries/users-queries.ts
@@ -78,3 +78,10 @@ export const updateUser = (userId: number, user: Partial<User>) => {
 
   return client.from("users").update(filteredUpdateData).eq("id", userId);
 };
+
+export const softDeleteUser = (userId: number) => {
+  return client
+    .from("users")
+    .update({ is_delete: true, updated_at: new Date().toISOString() })
+    .eq("id", userId);
+};

--- a/app/app/[locale]/(reception)/user-search/components/DisplayLimitInput.tsx
+++ b/app/app/[locale]/(reception)/user-search/components/DisplayLimitInput.tsx
@@ -1,0 +1,28 @@
+type Props = {
+  limit: number;
+  onLimitChange: (limit: number) => void;
+};
+
+export default function DisplayLimitInput({ limit, onLimitChange }: Props) {
+  const handleLimitChange = (limit: number) => {
+    onLimitChange(limit);
+  };
+
+  return (
+    <div className="flex justify-end">
+      <div>
+        <label className="mr-2" htmlFor="limit">
+          表示件数
+        </label>
+        <input
+          className="input-bordered w-24"
+          min={100}
+          step={100}
+          type="number"
+          value={limit}
+          onChange={(e) => handleLimitChange(Number(e.target.value))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/app/[locale]/(reception)/user-search/components/UserList.tsx
+++ b/app/app/[locale]/(reception)/user-search/components/UserList.tsx
@@ -1,16 +1,28 @@
 import Link from "next/link";
 import { MdEdit, MdNfc } from "react-icons/md";
+import DisplayLimitInput from "@/[locale]/(reception)/user-search/components/DisplayLimitInput";
+import SeatIcon from "@/components/icons/SeatIcon";
 import { User } from "@/types";
 
 type Props = {
   users: User[];
   onEditClicked: (user: User) => void;
+  limit: number;
+  setLimit: (limit: number) => void;
 };
 
-export default function UserList({ users, onEditClicked }: Props) {
+export default function UserList({
+  users,
+  onEditClicked,
+  limit,
+  setLimit,
+}: Props) {
   return (
     <div className="mt-6">
-      <h2 className="mb-4 text-xl font-bold">検索結果</h2>
+      <div className="flex justify-between">
+        <h2 className="mb-4 text-xl font-bold">検索結果</h2>
+        <DisplayLimitInput limit={limit} onLimitChange={setLimit} />
+      </div>
       {users.length > 0 ? (
         <ul className="space-y-4">
           {users.map((user) => (
@@ -33,6 +45,13 @@ export default function UserList({ users, onEditClicked }: Props) {
                   <MdEdit size={20} />
                   編集
                 </button>
+                <Link
+                  className="btn btn-sm btn-secondary"
+                  href={`/home?userId=${user.id}`}
+                >
+                  <SeatIcon size={20} />
+                  受付
+                </Link>
                 <Link
                   className="btn btn-sm btn-accent"
                   href={`/nfc-registration?userId=${user.id}`}

--- a/app/app/queries/user-search-queries.ts
+++ b/app/app/queries/user-search-queries.ts
@@ -11,15 +11,17 @@ export function fetchUsers(
     email?: boolean;
     phone?: boolean;
   },
+  limit: number = 100,
 ) {
-  let query = client.from("users").select("*").order("id", { ascending: true });
+  let query = client
+    .from("users")
+    .select("*")
+    .order("id", { ascending: false })
+    .is("is_delete", null)
+    .limit(limit);
 
   const conditions: string[] = [];
   const keyword = filters.searchText.trim();
-
-  if (keyword.length === 0) {
-    return Promise.resolve({ data: [], error: null }); //空を返す
-  }
 
   if (filters.id && keyword !== "" && !isNaN(Number(keyword))) {
     conditions.push(`id.eq.${Number(keyword)}`);


### PR DESCRIPTION
## 変更内容

- ユーザー編集フォームから削除（論理削除）を可能にした
- ユーザー検索ページの初期表示を最新の登録順のユーザーを表示に変更した

## 関連する Issue

Closes #136 135


## 変更理由

- 誤って登録された場合など、ユーザーを削除したい時に対応するため

- 受付側で利用者登録がされているかを確認できるようにして、２重登録を防止したい。


## スクリーンショット（UI の変更がある場合）

<img width="895" height="826" alt="スクリーンショット 2025-07-16 14 35 39" src="https://github.com/user-attachments/assets/53a0a1b6-94cd-4de5-b710-35dd6b980789" />

<img width="1033" height="786" alt="スクリーンショット 2025-07-16 14 35 51" src="https://github.com/user-attachments/assets/b1725333-14d6-4e29-a4fa-4b8233dd1a37" />

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->

