### PR TITLE
座席の利用不可を設定可能にする

### DIFF
--- a/app/app/[locale]/(reception)/home/client-components/EmptySeatModal.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/EmptySeatModal.tsx
@@ -8,12 +8,20 @@ import { EmptySeatModalBox } from "./EmptySeatModalBox";
 interface SeatModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onUpdateSeat: (
+    seatId: number,
+    seatParams: {
+      outOfService: boolean;
+      attentionMessage: string;
+    },
+  ) => void;
   seat: Seat | null;
 }
 
 export const EmptySeatModal: React.FC<SeatModalProps> = ({
   isOpen,
   onClose,
+  onUpdateSeat,
   seat,
 }) => {
   useKey("Escape", onClose, undefined, [isOpen]);
@@ -24,7 +32,11 @@ export const EmptySeatModal: React.FC<SeatModalProps> = ({
 
   return (
     <dialog className={`modal ${isOpen ? "modal-open" : ""}`} id="seat-modal">
-      <EmptySeatModalBox seat={seat} onClose={onClose} />
+      <EmptySeatModalBox
+        seat={seat}
+        onClose={onClose}
+        onUpdateSeat={onUpdateSeat}
+      />
       <div className="modal-backdrop" onClick={onClose}></div>
     </dialog>
   );

--- a/app/app/[locale]/(reception)/home/client-components/EmptySeatModalBox.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/EmptySeatModalBox.tsx
@@ -95,7 +95,9 @@ export const EmptySeatModalBox: React.FC<EmptySeatModalBoxProps> = ({
         </div>
       ) : (
         <div className="flex flex-col gap-[1rem] p-[2rem]">
-          <div>{seat.attentionMessage}</div>
+          <p className="text-error text-center text-sm whitespace-pre-wrap">
+            {seat.attentionMessage}
+          </p>
           <div className="flex flex-col gap-[1rem]">
             <ul className="list bg-base-100 rounded-box px-[0] shadow-md">
               <li className="list-row border-base-300 rounded-none border-b py-[0.5rem]">

--- a/app/app/[locale]/(reception)/home/client-components/EmptySeatModalBox.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/EmptySeatModalBox.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { MdSettings } from "react-icons/md";
 import ClockIcon from "@/components/icons/ClockIcon";
 import SeatIcon from "@/components/icons/SeatIcon";
 import UserIcon from "@/components/icons/UserIcon";
@@ -8,54 +10,128 @@ import { Seat } from "@/types";
 
 interface EmptySeatModalBoxProps {
   seat: Seat;
+  onUpdateSeat: (
+    seatId: number,
+    seatParams: {
+      outOfService: boolean;
+      attentionMessage: string;
+    },
+  ) => void;
   onClose: () => void;
 }
 
 export const EmptySeatModalBox: React.FC<EmptySeatModalBoxProps> = ({
   seat,
+  onUpdateSeat,
   onClose,
 }) => {
+  const [showEdit, setShowEdit] = useState(false);
+
+  const { register, handleSubmit } = useForm<{
+    outOfService: boolean;
+    attentionMessage: string;
+  }>({
+    defaultValues: {
+      outOfService: seat.outOfService,
+      attentionMessage: seat.attentionMessage,
+    },
+  });
+
+  const submit = (data: {
+    outOfService: boolean;
+    attentionMessage: string;
+  }) => {
+    onUpdateSeat(seat.id, data);
+    onClose();
+  };
+
   return (
     <div className="modal-box border-primary border-2 p-[0]">
-      <div className="bg-primary text-primary-content flex h-[50px] items-center justify-center text-[1.25rem] font-[800]">
-        空席
-      </div>
-      <div className="flex flex-col gap-[1rem] p-[2rem]">
-        <div className="flex flex-col gap-[1rem]">
-          <ul className="list bg-base-100 rounded-box px-[0] shadow-md">
-            <li className="list-row border-base-300 rounded-none border-b py-[0.5rem]">
-              <div>
-                <SeatIcon size={40} />
-              </div>
-              <div className="flex items-center align-[middle] text-[1.25rem]">
-                <div>{seat.name}</div>
-              </div>
-            </li>
-            <li className="list-row border-base-300 rounded-none border-b py-[0.5rem]">
-              <div>
-                <UserIcon size={40} />
-              </div>
-              <div className="flex items-center align-[middle] text-[1.25rem]">
-                <div></div>
-              </div>
-            </li>
-            <li className="list-row border-base-300 rounded-none border-b py-[0.5rem]">
-              <div>
-                <ClockIcon size={40} />
-              </div>
-              <div className="flex items-center align-[middle] text-[1.25rem]">
-                <div></div>
-              </div>
-            </li>
-          </ul>
-        </div>
+      <div className="bg-primary text-primary-content flex h-[50px] items-center justify-center gap-4 text-[1.25rem] font-[800]">
+        {seat.outOfService ? <p>空席(使用不可)</p> : <p>空席</p>}
 
-        <div className="mx-auto">
-          <button className="btn btn-secondary" onClick={onClose}>
-            閉じる
-          </button>
-        </div>
+        <MdSettings
+          className="absolute right-4 cursor-pointer"
+          size={20}
+          onClick={() => setShowEdit(!showEdit)}
+        />
       </div>
+
+      {showEdit ? (
+        <div className="flex w-full flex-col gap-[1rem] p-[2rem]">
+          <form onSubmit={handleSubmit(submit)}>
+            <div className="flex w-full flex-col gap-[1rem]">
+              <div className="flex flex-col gap-[0.5rem]">
+                <label className="text-sm">使用可否</label>
+                <select
+                  className="select select-bordered"
+                  {...register("outOfService")}
+                >
+                  <option value="false">使用可能</option>
+                  <option value="true">使用不可</option>
+                </select>
+              </div>
+
+              <div className="p-2">
+                <label>注意事項</label>
+                <textarea
+                  className="textarea textarea-bordered w-full"
+                  {...register("attentionMessage")}
+                />
+              </div>
+            </div>
+            <div className="mx-auto flex justify-around gap-[1rem]">
+              <button
+                className="btn btn-secondary"
+                onClick={() => setShowEdit(!showEdit)}
+              >
+                戻る
+              </button>
+              <button className="btn btn-primary" type="submit">
+                変更する
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-[1rem] p-[2rem]">
+          <div>{seat.attentionMessage}</div>
+          <div className="flex flex-col gap-[1rem]">
+            <ul className="list bg-base-100 rounded-box px-[0] shadow-md">
+              <li className="list-row border-base-300 rounded-none border-b py-[0.5rem]">
+                <div>
+                  <SeatIcon size={40} />
+                </div>
+                <div className="flex items-center align-[middle] text-[1.25rem]">
+                  <div>{seat.name}</div>
+                </div>
+              </li>
+              <li className="list-row border-base-300 rounded-none border-b py-[0.5rem]">
+                <div>
+                  <UserIcon size={40} />
+                </div>
+                <div className="flex items-center align-[middle] text-[1.25rem]">
+                  <div></div>
+                </div>
+              </li>
+              <li className="list-row border-base-300 rounded-none border-b py-[0.5rem]">
+                <div>
+                  <ClockIcon size={40} />
+                </div>
+                <div className="flex items-center align-[middle] text-[1.25rem]">
+                  <div></div>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <div className="mx-auto">
+            <button className="btn btn-secondary" onClick={onClose}>
+              閉じる
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/app/[locale]/(reception)/home/client-components/SeatAreaMap.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/SeatAreaMap.tsx
@@ -15,6 +15,13 @@ type SeatAreaMapProps = {
   onFinishSeatUsage: (seatUsage: SeatUsage) => void;
   onMoveSeat: (prevSeatUsage: SeatUsage, nextSeatUsage: SeatUsage) => void;
   onAssignSeat: (seat: Seat, user: User, startTime?: string) => void;
+  onUpdateSeat: (
+    seatId: number,
+    seatParams: {
+      outOfService: boolean;
+      attentionMessage: string;
+    },
+  ) => void;
 };
 
 export const SeatAreaMap: FC<SeatAreaMapProps> = ({
@@ -25,6 +32,7 @@ export const SeatAreaMap: FC<SeatAreaMapProps> = ({
   onFinishSeatUsage,
   onMoveSeat,
   onAssignSeat,
+  onUpdateSeat,
 }) => {
   const [selectedSeat, setSelectedSeat] = useState<Seat | null>(null);
   const [selectedSeatUsage, setSelectedSeatUsage] = useState<SeatUsage | null>(
@@ -52,7 +60,9 @@ export const SeatAreaMap: FC<SeatAreaMapProps> = ({
         return (
           <InUseSeatModal
             emptySeats={seats.filter(
-              (seat) => !seatUsages.some((usage) => usage.seatId === seat.id),
+              (seat) =>
+                !seat.outOfService &&
+                !seatUsages.some((usage) => usage.seatId === seat.id),
             )}
             isOpen={Boolean(selectedSeat)}
             seat={selectedSeat}
@@ -89,6 +99,7 @@ export const SeatAreaMap: FC<SeatAreaMapProps> = ({
             onClose={() => {
               setSelectedSeat(null);
             }}
+            onUpdateSeat={onUpdateSeat}
           />
         );
       }

--- a/app/app/[locale]/(reception)/home/client-components/SeatCard.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/SeatCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { MdAccessAlarm } from "react-icons/md";
+import { MdAccessAlarm, MdComment } from "react-icons/md";
 import { MdAccessTime } from "react-icons/md";
 import SeatIcon from "@/components/icons/SeatIcon";
 import UserIcon from "@/components/icons/UserIcon";
@@ -32,8 +32,13 @@ const SeatCard: React.FC<SeatProps> = ({
     >
       <div className="card-body">
         {seat.outOfService && (
-          <div className="text-error text-center text-xs">
+          <div className="text-error text-center text-xs font-bold">
             <span className="text-error">使用不可</span>
+          </div>
+        )}
+        {seat.attentionMessage && (
+          <div className="text-error absolute top-1 right-0 text-center text-xs">
+            <MdComment className="mr-1" size={16} />
           </div>
         )}
         <div className="flex flex-row items-center gap-[0.125rem]">

--- a/app/app/[locale]/(reception)/home/client-components/SeatCard.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/SeatCard.tsx
@@ -27,10 +27,15 @@ const SeatCard: React.FC<SeatProps> = ({
 
   return (
     <div
-      className={`card card-xs card-border ${seatUsage?.userId ? "border-accent bg-accent/30" : "border-primary"} h-[8rem] w-[7rem] cursor-pointer`}
+      className={`card card-xs card-border ${seatUsage?.userId ? "border-accent bg-accent/30" : "border-primary"} ${seat.outOfService ? "bg-gray-200" : ""} h-[8rem] w-[7rem] cursor-pointer`}
       onClick={() => onSeatClick(seat, seatUsage)}
     >
       <div className="card-body">
+        {seat.outOfService && (
+          <div className="text-error text-center text-xs">
+            <span className="text-error">使用不可</span>
+          </div>
+        )}
         <div className="flex flex-row items-center gap-[0.125rem]">
           <SeatIcon />
           <div>

--- a/app/app/[locale]/(reception)/hooks/use-seats-with-category.test.ts
+++ b/app/app/[locale]/(reception)/hooks/use-seats-with-category.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import humps from "humps";
 import { getSeatsWithCategory } from "@/[locale]/(reception)/queries/seats-queries";
 import { useSeatsWithCategory } from "./use-seats-with-category";
 
@@ -25,6 +26,8 @@ const mockSeatsData = [
   },
 ];
 
+const camelizedMockSeatsData = humps.camelizeKeys(mockSeatsData);
+
 describe("useSeatsWithCategory", () => {
   beforeEach(() => {
     (getSeatsWithCategory as jest.Mock).mockResolvedValue({
@@ -37,26 +40,7 @@ describe("useSeatsWithCategory", () => {
     const { result } = renderHook(() => useSeatsWithCategory());
 
     await waitFor(() => {
-      expect(result.current.seats).toEqual([
-        {
-          id: 1,
-          name: "座席1",
-          categoryId: 1,
-          seatCategory: { id: 1, name: "カテゴリ1" },
-        },
-        {
-          id: 2,
-          name: "座席2",
-          categoryId: 2,
-          seatCategory: { id: 2, name: "カテゴリ2" },
-        },
-        {
-          id: 3,
-          name: "座席3",
-          categoryId: 1,
-          seatCategory: { id: 1, name: "カテゴリ1" },
-        },
-      ]);
+      expect(result.current.seats).toEqual(camelizedMockSeatsData);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
     });
@@ -78,5 +62,14 @@ describe("useSeatsWithCategory", () => {
         expect(result.current.error).toBeInstanceOf(Error);
       });
     });
+  });
+
+  it("should refetch seats", async () => {
+    const { result } = renderHook(() => useSeatsWithCategory());
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(result.current.seats).toEqual(camelizedMockSeatsData);
   });
 });

--- a/app/app/[locale]/(reception)/hooks/use-seats-with-category.ts
+++ b/app/app/[locale]/(reception)/hooks/use-seats-with-category.ts
@@ -9,22 +9,22 @@ export const useSeatsWithCategory = () => {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    const fetchSeats = async () => {
-      setIsLoading(true);
-      const { data, error } = await getSeatsWithCategory();
-
-      if (error) {
-        setError(error);
-        setIsLoading(false);
-        return;
-      }
-      const camelizedData = humps.camelizeKeys(data);
-      setSeats(camelizedData as SeatWithCategory[]);
-      setIsLoading(false);
-    };
-
     fetchSeats();
   }, []);
 
-  return { seats, isLoading, error };
+  const fetchSeats = async () => {
+    setIsLoading(true);
+    const { data, error } = await getSeatsWithCategory();
+
+    if (error) {
+      setError(error);
+      setIsLoading(false);
+      return;
+    }
+    const camelizedData = humps.camelizeKeys(data);
+    setSeats(camelizedData as SeatWithCategory[]);
+    setIsLoading(false);
+  };
+
+  return { seats, isLoading, error, refetch: fetchSeats };
 };

--- a/app/app/[locale]/(reception)/hooks/use-update-seat.test.ts
+++ b/app/app/[locale]/(reception)/hooks/use-update-seat.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from "@testing-library/react";
+import * as seatQueries from "@/[locale]/(reception)/queries/seats-queries";
+import { useUpdateSeat } from "./use-update-seat";
+
+jest.mock("@/[locale]/(reception)/queries/seats-queries");
+
+describe("useUpdateSeat", () => {
+  const seatData = {
+    id: 1,
+    name: "seat_name",
+    attentionMessage: "seat_attention_message",
+    outOfService: false,
+  };
+  const mockSeat = {
+    id: 1,
+    name: "seat_name",
+    attentionMessage: "seat_attention_message",
+    outOfService: false,
+  };
+
+  beforeEach(() => {
+    (seatQueries.updateSeat as jest.Mock).mockResolvedValue({
+      error: null,
+    });
+    (seatQueries.fetchSeatWithCategory as jest.Mock).mockResolvedValue({
+      data: mockSeat,
+      error: null,
+    });
+  });
+
+  it("should update user", async () => {
+    const { result } = renderHook(() => useUpdateSeat());
+
+    await act(async () => {
+      const updatedSeat = await result.current.update(1, seatData);
+      expect(seatQueries.updateSeat).toHaveBeenCalledWith(1, seatData);
+      expect(seatQueries.fetchSeatWithCategory).toHaveBeenCalledWith(1);
+      expect(updatedSeat).toEqual(mockSeat);
+    });
+  });
+
+  it("should return error when updateSeat fails", async () => {
+    (seatQueries.updateSeat as jest.Mock).mockResolvedValue({
+      error: new Error("Update failed"),
+    });
+    const { result } = renderHook(() => useUpdateSeat());
+    await act(async () => {
+      const updatedSeat = await result.current.update(1, seatData);
+      expect(updatedSeat).toBeNull();
+    });
+    expect(result.current.error?.message).toEqual("Update failed");
+  });
+
+  it("should return error when fetchSeatWithCategory fails", async () => {
+    (seatQueries.fetchSeatWithCategory as jest.Mock).mockResolvedValue({
+      error: new Error("Fetch failed"),
+    });
+    const { result } = renderHook(() => useUpdateSeat());
+    await act(async () => {
+      const updatedSeat = await result.current.update(1, seatData);
+      expect(updatedSeat).toBeNull();
+    });
+    expect(result.current.error).toEqual(new Error("Fetch failed"));
+  });
+});

--- a/app/app/[locale]/(reception)/hooks/use-update-seat.ts
+++ b/app/app/[locale]/(reception)/hooks/use-update-seat.ts
@@ -1,0 +1,56 @@
+import humps from "humps";
+import { useState } from "react";
+import {
+  fetchSeatWithCategory,
+  updateSeat,
+} from "@/[locale]/(reception)/queries/seats-queries";
+import { Seat } from "@/types";
+
+export const useUpdateSeat = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // ユーザーを更新する
+  //@param seatId 座席ID
+  //@param seatParams 座席パラメータ
+  //@returns 更新後の座席データ
+  const update = async (
+    seatId: number,
+    seatParams: {
+      outOfService: boolean;
+      attentionMessage: string;
+    },
+  ): Promise<Seat | null> => {
+    try {
+      setError(null);
+      setIsLoading(true);
+
+      const { error } = await updateSeat(seatId, seatParams);
+      if (error) {
+        setError(error);
+        setIsLoading(false);
+        return null;
+      }
+
+      const { data, error: fetchError } = await fetchSeatWithCategory(seatId);
+      if (fetchError) {
+        setError(fetchError);
+        setIsLoading(false);
+        return null;
+      }
+
+      return humps.camelizeKeys(data) as Seat;
+    } catch (error) {
+      setError(error as Error);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    update,
+    isLoading,
+    error,
+  };
+};

--- a/app/app/[locale]/(reception)/queries/seats-queries.ts
+++ b/app/app/[locale]/(reception)/queries/seats-queries.ts
@@ -1,9 +1,33 @@
 import client from "@/utils/supabase/client";
 
 export const getSeats = async () => {
-  return client.from("seats").select("*");
+  return client.from("seats").select("*").order("id", { ascending: true });
 };
 
 export const getSeatsWithCategory = async () => {
-  return client.from("seats").select("*, seat_category:seat_categories(*)");
+  return client
+    .from("seats")
+    .select("*, seat_category:seat_categories(*)")
+    .order("order", { ascending: true });
+};
+
+export const fetchSeatWithCategory = async (seatId: number) => {
+  return client
+    .from("seats")
+    .select("*, seat_category:seat_categories(*)")
+    .eq("id", seatId)
+    .maybeSingle();
+};
+
+export const updateSeat = async (
+  seatId: number,
+  seatParams: { outOfService: boolean; attentionMessage: string },
+) => {
+  return client
+    .from("seats")
+    .update({
+      out_of_service: seatParams.outOfService,
+      attention_message: seatParams.attentionMessage,
+    })
+    .eq("id", seatId);
 };

--- a/app/app/types/seat.d.ts
+++ b/app/app/types/seat.d.ts
@@ -2,6 +2,9 @@
 export type Seat = {
   id: number;
   name: string;
+  outOfService: boolean;
+  attentionMessage: string;
+  order: number;
   categoryId: number;
   createdAt?: string;
   updatedAt?: string;

--- a/app/app/utils/supabase/database.types.ts
+++ b/app/app/utils/supabase/database.types.ts
@@ -17,9 +17,9 @@ export type Database = {
     Functions: {
       graphql: {
         Args: {
+          variables?: Json;
           operationName?: string;
           query?: string;
-          variables?: Json;
           extensions?: Json;
         };
         Returns: Json;
@@ -380,18 +380,21 @@ export type Database = {
           description: string | null;
           id: number;
           name: string;
+          order: number | null;
         };
         Insert: {
           created_at?: string | null;
           description?: string | null;
           id?: never;
           name: string;
+          order?: number | null;
         };
         Update: {
           created_at?: string | null;
           description?: string | null;
           id?: never;
           name?: string;
+          order?: number | null;
         };
         Relationships: [];
       };
@@ -448,22 +451,31 @@ export type Database = {
       };
       seats: {
         Row: {
+          attention_message: string;
           category_id: number;
           created_at: string | null;
           id: number;
           name: string;
+          order: number;
+          out_of_service: boolean;
         };
         Insert: {
+          attention_message?: string;
           category_id: number;
           created_at?: string | null;
           id?: never;
           name: string;
+          order?: number;
+          out_of_service?: boolean;
         };
         Update: {
+          attention_message?: string;
           category_id?: number;
           created_at?: string | null;
           id?: never;
           name?: string;
+          order?: number;
+          out_of_service?: boolean;
         };
         Relationships: [
           {

--- a/supabase/migrations/20250723082845_add_out_of_service_flag_to_seats.sql
+++ b/supabase/migrations/20250723082845_add_out_of_service_flag_to_seats.sql
@@ -1,0 +1,11 @@
+-- Add out_of_service flag to seats table
+ALTER TABLE public.seats
+ADD COLUMN out_of_service BOOLEAN DEFAULT FALSE NOT NULL;
+
+-- Add attention_message to seats table 注意事項
+ALTER TABLE public.seats
+ADD COLUMN attention_message TEXT NOT NULL DEFAULT '';
+
+-- Add order to seats table リスト表示順
+ALTER TABLE public.seats
+ADD COLUMN "order" INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## 変更内容

- seatテーブルにout_of_serveフラグを追加
- 座席一覧の利用不可を表示可能にした
- 空席モーダルに座席の利用可否等を変更フォームを追加
- 利用不可の座席を受付時のリストに表示させないよう変更

## 関連する Issue

Closes #142

## 変更理由

座席が利用できない場合の対応

## スクリーンショット（UI の変更がある場合）


## 動作確認

- [ ] ローカル環境で動作確認済み
- [ ] ユニットテストが通過している
- [ ] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
