### PR TITLE
一括延長で利用時間超過されたものがチェックされないことがある不具合の修正

### DIFF
--- a/app/app/[locale]/(reception)/components/BatchExtendSeatsModal.tsx
+++ b/app/app/[locale]/(reception)/components/BatchExtendSeatsModal.tsx
@@ -31,6 +31,8 @@ export const BatchExtendSeatsModal: React.FC<BatchExtendSeatsModalProps> = ({
   >([]);
 
   useEffect(() => {
+    if (!isOpen) return;
+
     setSeatUsagesWithSelected(
       seatUsages.map((seatUsage) => {
         const endTime = seatUsage?.startTime
@@ -47,7 +49,7 @@ export const BatchExtendSeatsModal: React.FC<BatchExtendSeatsModalProps> = ({
         };
       }),
     );
-  }, [seatUsages, seats]);
+  }, [seatUsages, seats, isOpen]);
 
   const handleChangeSelected = (
     seatUsageWithSelected: SeatUsageWithSelected,


### PR DESCRIPTION
## 変更内容

useEffectの依存を変更

## 関連する Issue

Closes #162

## 変更理由

useEffectで利用時間超過をチェックしていたが、依存関係の不備でページを開いた時にチェックするようになっており、時間が経過するとチェックされないことがあった。
依存関係にモーダルオープンフラグを追加して、モーダルが開いた時にチェックを実行させるように修正した。

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
