### PR TITLE
最終利用日時を会員番号検索時に表示させる

### DIFF
--- a/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
@@ -12,8 +12,10 @@ import { useKey } from "react-use";
 import { useDebounce } from "use-debounce";
 import CardReaderControlButton from "@/[locale]/(reception)/components/CardReaderControlButton";
 import AssignSeatConfirmModal from "@/[locale]/(reception)/home/client-components/AssignSeatConfirmModal";
+import UsageIntervalLabel from "@/[locale]/(reception)/home/client-components/UsageIntervalLabel";
 import UserIcon from "@/components/icons/UserIcon";
 import { Seat, User } from "@/types";
+import { formatDate } from "@/utils/format-date-time";
 
 interface ReceptionFormProps {
   searchWord: string;
@@ -294,6 +296,17 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
                     <div className="text-sm">{user.name}</div>
                     <div className="ml-2 text-sm">({user.pronunciation})</div>
                   </div>
+                  {user.latestSeatUsage && (
+                    <div className="flex flex-row gap-1 text-sm">
+                      <div>
+                        前回:
+                        {formatDate(user.latestSeatUsage.startTime)}
+                      </div>
+                      <div>
+                        <UsageIntervalLabel seatUsage={user.latestSeatUsage} />
+                      </div>
+                    </div>
+                  )}
                 </li>
               ))}
             </ul>

--- a/app/app/[locale]/(reception)/home/client-components/UsageIntervalLabel.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/UsageIntervalLabel.tsx
@@ -1,0 +1,39 @@
+import { SeatUsage } from "@/types";
+
+// 利用間隔を表示するラベル
+// 間隔が1年以上の場合は、◯年◯ヶ月と表示する
+// 間隔が1ヶ月以上の場合は、◯ヶ月と表示する
+// 間隔が1ヶ月未満の場合は、◯日と表示する
+// 間隔が1日未満の場合は、非表示とする
+const UsageIntervalLabel = ({ seatUsage }: { seatUsage: SeatUsage }) => {
+  const usageIntervalDays = seatUsage.startTime
+    ? Math.floor(
+        (new Date().getTime() - new Date(seatUsage.startTime).getTime()) /
+          (1000 * 60 * 60 * 24),
+      )
+    : 0;
+  const usageIntervalMonths = seatUsage.startTime
+    ? Math.floor(
+        (new Date().getTime() - new Date(seatUsage.startTime).getTime()) /
+          (1000 * 60 * 60 * 24 * 30),
+      )
+    : 0;
+  const usageIntervalYears = seatUsage.startTime
+    ? Math.floor(
+        (new Date().getTime() - new Date(seatUsage.startTime).getTime()) /
+          (1000 * 60 * 60 * 24 * 365),
+      )
+    : 0;
+  const usageIntervalLabel =
+    usageIntervalYears > 0
+      ? `${usageIntervalYears}年${usageIntervalMonths}ヶ月`
+      : usageIntervalMonths > 0
+        ? `${usageIntervalMonths}ヶ月`
+        : usageIntervalDays > 0
+          ? `${usageIntervalDays}日`
+          : "";
+
+  return <div>({usageIntervalLabel}前)</div>;
+};
+
+export default UsageIntervalLabel;

--- a/app/app/[locale]/(reception)/home/page.tsx
+++ b/app/app/[locale]/(reception)/home/page.tsx
@@ -119,7 +119,7 @@ export default function HomePage() {
         setSearchUserKeyword("");
       } else {
         setSearchUserKeyword(searchWord);
-        await fetchUsers(searchWord);
+        await fetchUsers(searchWord, true);
       }
     },
     [clearSearchUsers, fetchUsers],

--- a/app/app/[locale]/(reception)/hooks/use-search-users.ts
+++ b/app/app/[locale]/(reception)/hooks/use-search-users.ts
@@ -1,14 +1,15 @@
 import humps from "humps";
 import { useState } from "react";
+import { fetchLatestSeatUsageByUserId } from "@/[locale]/(reception)/queries/seat-usages-queries";
 import { fetchUsersBySearchParams } from "@/[locale]/(reception)/queries/users-queries";
-import { User } from "@/types";
+import { SeatUsage, User } from "@/types";
 
 export const useSearchUsers = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const fetch = async (keyword?: string) => {
+  const fetch = async (keyword?: string, withLatestSeatUsage?: boolean) => {
     setIsLoading(true);
     // 数値のみの場合はidとして扱う
     const id = keyword?.match(/^\d+$/) ? Number(keyword) : undefined;
@@ -32,8 +33,25 @@ export const useSearchUsers = () => {
       return;
     }
 
-    const camelizedData = humps.camelizeKeys(data);
-    setUsers(camelizedData as User[]);
+    let camelizedData = humps.camelizeKeys(data) as User[];
+
+    if (withLatestSeatUsage) {
+      camelizedData = await Promise.all(
+        camelizedData.map(async (user) => {
+          const { data: latestSeatUsageData, error: latestSeatUsageError } =
+            await fetchLatestSeatUsageByUserId(user.id);
+          if (latestSeatUsageError) {
+            return user;
+          }
+          user.latestSeatUsage = humps.camelizeKeys(
+            latestSeatUsageData,
+          ) as SeatUsage;
+          return user;
+        }),
+      );
+    }
+
+    setUsers(camelizedData);
     setIsLoading(false);
   };
 

--- a/app/app/[locale]/(reception)/queries/seat-usages-queries.ts
+++ b/app/app/[locale]/(reception)/queries/seat-usages-queries.ts
@@ -100,3 +100,18 @@ export const updateSeatUsageIsDeleted = async (
     .update({ is_delete: is_delete })
     .eq("id", id);
 };
+
+/**
+ * ユーザーの最新の利用履歴を取得
+ * @param userId 対象のユーザーID
+ * @returns 検索結果
+ */
+export const fetchLatestSeatUsageByUserId = async (userId: number) => {
+  return client
+    .from("seat_usage_logs")
+    .select("*")
+    .eq("user_id", userId)
+    .order("start_time", { ascending: false })
+    .limit(1)
+    .single();
+};

--- a/app/app/types/user.d.ts
+++ b/app/app/types/user.d.ts
@@ -21,4 +21,5 @@ export type User = {
   warnings: string;
   createdAt: string;
   updatedAt: string;
+  latestSeatUsage?: SeatUsage;
 };

--- a/app/app/utils/format-date-time.ts
+++ b/app/app/utils/format-date-time.ts
@@ -4,3 +4,8 @@ export const formatDateTime = (dateTimeString: string) => {
   const date = new Date(dateTimeString);
   return format(date, "yyyy/MM/dd HH:mm:ss");
 };
+
+export const formatDate = (dateTimeString: string) => {
+  const date = new Date(dateTimeString);
+  return format(date, "yyyy/MM/dd");
+};


### PR DESCRIPTION
## 変更内容

最終利用日時を会員番号検索時に表示させる

## 関連する Issue


Closes #166

## 変更理由

受付で何ヶ月ぶりなど把握しやすくするため

## スクリーンショット（UI の変更がある場合）

<img width="1361" height="691" alt="スクリーンショット 2025-08-15 20 20 33" src="https://github.com/user-attachments/assets/d0df6de2-c68a-47bd-be05-8fdc250043c5" />


## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
