### PR TITLE
feat(app): remove report page from header menu

### DIFF
--- a/app/app/[locale]/(reception)/components/Header.tsx
+++ b/app/app/[locale]/(reception)/components/Header.tsx
@@ -16,10 +16,6 @@ const navLinks = [
     href: "/usage-logs",
   },
   {
-    label: "レポート",
-    href: "/reports",
-  },
-  {
     label: "カード (NFC) 登録",
     href: "/nfc-registration",
   },


### PR DESCRIPTION
## 変更内容

ヘッダーメニューからレポートを削除

## 関連する Issue

Closes #160

## 変更理由

レポートページを誰でも見れない方が良いとの要望から

## スクリーンショット（UI の変更がある場合）

<img width="691" height="93" alt="スクリーンショット 2025-08-20 10 19 00" src="https://github.com/user-attachments/assets/fdce7ccf-73d4-4028-89dd-ba9953b65a5d" />


## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

完全な閲覧制限は別途実装予定
ひとまず動線の制限を行う
