### PR TITLE
Fix: 座席延長バッチ実行のエンターキー問題を修正

### DIFF
--- a/app/app/[locale]/(reception)/components/BatchExtendSeatsModal.tsx
+++ b/app/app/[locale]/(reception)/components/BatchExtendSeatsModal.tsx
@@ -91,8 +91,14 @@ export const BatchExtendSeatsModal: React.FC<BatchExtendSeatsModalProps> = ({
   }, [isOpen, onClose]);
 
   // useKeyでキーボードイベントをハンドリング
-  useKey("Enter", handleKeyboardExecute, undefined, [isOpen]);
-  useKey("Escape", handleKeyboardClose, undefined, [isOpen]);
+  useKey("Enter", handleKeyboardExecute, undefined, [
+    isOpen,
+    handleKeyboardExecute,
+  ]);
+  useKey("Escape", handleKeyboardClose, undefined, [
+    isOpen,
+    handleKeyboardClose,
+  ]);
 
   return (
     <dialog


### PR DESCRIPTION
## 変更内容

BatchExtendSeatsModalコンポーネントのuseKeyフックの依存配列を修正し、エンターキーでの座席延長バッチ実行が正常に動作するようにしました。

## 関連する Issue

Closes #172

## 変更理由

座席延長のバッチ実行機能において、エンターキーで実行すると更新されない問題が発生していました。原因はuseKeyフックの依存配列にhandleKeyboardExecuteが含まれていないことでした。これにより、座席選択状態の変更時にキーボードハンドラーが適切に更新されず、古い選択状態で処理が実行されていました。

## スクリーンショット（UI の変更がある場合）

UIの変更はありません。キーボードショートカットの動作のみが修正されています。

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

### 修正詳細
- 修正前: `useKey("Enter", handleKeyboardExecute, undefined, [isOpen])`
- 修正後: `useKey("Enter", handleKeyboardExecute, undefined, [isOpen, handleKeyboardExecute])`

### 影響範囲
- 座席延長のバッチ実行（エンターキーでの実行のみ）
- マウスクリックでの「実行する」ボタンは影響なし
