### PR TITLE
座席アサインなどの時に受付フォームのsearchTypeを番号検索に戻すようにした

### DIFF
--- a/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
+++ b/app/app/[locale]/(reception)/home/client-components/ReceptionForm.tsx
@@ -15,6 +15,7 @@ import AssignSeatConfirmModal from "@/[locale]/(reception)/home/client-component
 import UsageIntervalLabel from "@/[locale]/(reception)/home/client-components/UsageIntervalLabel";
 import UserIcon from "@/components/icons/UserIcon";
 import { Seat, User } from "@/types";
+import { ReceptionSearchType } from "@/types/receptionSearchType";
 import { formatDate } from "@/utils/format-date-time";
 
 interface ReceptionFormProps {
@@ -23,6 +24,7 @@ interface ReceptionFormProps {
   searchNfcError: string | null;
   emptySeats: Seat[];
   selectedUser: User | null;
+  searchType: ReceptionSearchType;
   onSelectUser: (user: User | null) => void;
   onChangeSearchWord: (input: string, searchType: string) => void;
   onClose: () => void;
@@ -36,6 +38,7 @@ interface ReceptionFormProps {
     usageDurationMinutes?: number,
   ) => void;
   onEditUser: (user: User) => void;
+  onChangeSearchType: (searchType: ReceptionSearchType) => void;
 }
 
 const ReceptionForm: React.FC<ReceptionFormProps> = ({
@@ -44,6 +47,7 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
   searchNfcError,
   emptySeats,
   selectedUser,
+  searchType,
   onSelectUser,
   onChangeSearchWord,
   onClose,
@@ -52,6 +56,7 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
   onDisconnectUsbDevice,
   assignSeat,
   onEditUser,
+  onChangeSearchType,
 }) => {
   const [selectedUserIndex, setSelectedUserIndex] = useState<number>(0);
   const [selectedArea, setSelectedArea] = useState<string | null>(null);
@@ -60,7 +65,6 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
   const [searchFormValue, setSearchFormValue] = useState<string>(searchWord);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const [debouncedChangeSearchWord] = useDebounce(searchFormValue, 250);
-  const [searchType, setSearchType] = useState<string>("user_id");
 
   // インクリメンタルサーチ
   useEffect(() => {
@@ -255,13 +259,13 @@ const ReceptionForm: React.FC<ReceptionFormProps> = ({
                 >
                   <li
                     className="hover:bg-base-200 cursor-pointer"
-                    onClick={() => setSearchType("user_id")}
+                    onClick={() => onChangeSearchType("user_id")}
                   >
                     会員番号
                   </li>
                   <li
                     className="hover:bg-base-200 cursor-pointer"
-                    onClick={() => setSearchType("information")}
+                    onClick={() => onChangeSearchType("information")}
                   >
                     会員情報
                   </li>

--- a/app/app/[locale]/(reception)/home/page.tsx
+++ b/app/app/[locale]/(reception)/home/page.tsx
@@ -17,6 +17,7 @@ import { softDeleteUser } from "@/[locale]/(reception)/queries/users-queries";
 import { useRegistrationOptions } from "@/hooks/use-registration-options";
 import { useSession } from "@/hooks/use-session";
 import { Seat, SeatUsage, User } from "@/types";
+import { ReceptionSearchType } from "@/types/receptionSearchType";
 import { addMinutes } from "@/utils/format-time";
 import ReceptionForm from "./client-components/ReceptionForm";
 import { SeatAreaMap } from "./client-components/SeatAreaMap";
@@ -31,6 +32,7 @@ export default function HomePage() {
       ? searchParamUserId
       : undefined;
   const [searchUserKeyword, setSearchUserKeyword] = useState<string>("");
+  const [searchType, setSearchType] = useState<ReceptionSearchType>("user_id");
   const [editUser, setEditUser] = useState<User | null>(null);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [isBatchExtendSeatsModalOpen, setIsBatchExtendSeatsModalOpen] =
@@ -111,7 +113,7 @@ export default function HomePage() {
     if (userId === null) {
       return;
     }
-
+    setSearchType("user_id");
     setSearchUserKeyword(userId.toString());
   };
 
@@ -171,6 +173,7 @@ export default function HomePage() {
         usageDurationMinutes || seat.usageDurationMinutes,
       );
       await fetchInUseSeatUsage();
+      setSearchType("user_id");
       setSearchUserKeyword("");
       handleFormClose();
     },
@@ -290,9 +293,11 @@ export default function HomePage() {
               !seatUsages.some((usage) => usage.seatId === seat.id),
           )}
           searchNfcError={searchUserKeyword ? null : searchNfcError}
+          searchType={searchType}
           searchUserList={isLoading ? null : users}
           searchWord={searchUserKeyword}
           selectedUser={selectedUser}
+          onChangeSearchType={setSearchType}
           onChangeSearchWord={handleChangeSearchWord}
           onClose={handleFormClose}
           onConnectUsbDevice={handleConnectUsbDevice}

--- a/app/app/types/receptionSearchType.ts
+++ b/app/app/types/receptionSearchType.ts
@@ -1,0 +1,1 @@
+export type ReceptionSearchType = "user_id" | "information";


### PR DESCRIPTION
## 変更内容
座席アサイン、NFC読み取り時に受付フォームのsearchTypeを番号検索に戻すように変更した

## 関連する Issue

Closes #181

## 変更理由

searchTypeを戻すのを忘れて、正しい利用者が出てこないケースがあるため

## スクリーンショット（UI の変更がある場合）

<!-- UIに変更がある場合はスクリーンショットを貼ってください -->
<!-- 例: ![image](URL) -->

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] ユニットテストが通過している
- [x] 必要に応じてドキュメントを更新した

## その他

<!-- 補足情報があれば記入してください -->
