### PR TITLE
fix: align locale route param types

### DIFF
--- a/app/app/[locale]/(registration)/registration/page.tsx
+++ b/app/app/[locale]/(registration)/registration/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import { Locale, useTranslations } from "next-intl";
+import { hasLocale, useTranslations } from "next-intl";
 import { use, useState } from "react";
 import { useForm } from "react-hook-form";
 import { MdErrorOutline } from "react-icons/md";
@@ -21,13 +21,19 @@ import { useSubmitRegistration } from "@/[locale]/(registration)/registration/ho
 import { registrationSchema } from "@/[locale]/(registration)/registration/schemas/registration-schema";
 import { RegistrationSchema } from "@/[locale]/(registration)/registration/types";
 import { useRegistrationOptions } from "@/hooks/use-registration-options";
+import { routing } from "~/i18n/routing";
 
 export default function Registration({
   params,
 }: {
-  params: Promise<{ locale: Locale }>;
+  params: Promise<{ locale: string }>;
 }) {
   const { locale } = use(params);
+
+  if (!hasLocale(routing.locales, locale)) {
+    throw new Error(`Invalid locale: ${locale}`);
+  }
+
   const t = useTranslations("Registration");
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [createdUserId, setCreatedUserId] = useState<number>();

--- a/app/app/[locale]/layout.tsx
+++ b/app/app/[locale]/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { notFound } from "next/navigation";
-import { hasLocale, Locale, NextIntlClientProvider } from "next-intl";
+import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { ReactNode } from "react";
 import NfcPortLibLoader from "@/components/NfcPortLibLoader";
 import ReactQueryClientProvider from "@/components/ReactQueryClientProvider";
@@ -33,7 +33,7 @@ export default async function LocaleLayout({
   params,
 }: {
   children: ReactNode;
-  params: Promise<{ locale: Locale }>;
+  params: Promise<{ locale: string }>;
 }) {
   // Ensure that the incoming `locale` is valid
   const { locale } = await params;

--- a/app/app/[locale]/page.tsx
+++ b/app/app/[locale]/page.tsx
@@ -1,13 +1,19 @@
-import { Locale } from "next-intl";
+import { notFound } from "next/navigation";
+import { hasLocale } from "next-intl";
 import { use } from "react";
 import { redirect } from "~/i18n/navigation";
+import { routing } from "~/i18n/routing";
 
 export default function IndexPage({
   params,
 }: {
-  params: Promise<{ locale: Locale }>;
+  params: Promise<{ locale: string }>;
 }) {
   const { locale } = use(params);
+
+  if (!hasLocale(routing.locales, locale)) {
+    notFound();
+  }
 
   redirect({ href: "/home", locale });
 }


### PR DESCRIPTION
## Summary
- align localized app route `params` types with Next.js app router expectations
- validate `locale` at runtime before redirecting or using locale-specific pages
- fix the build failure caused by narrowing route params to `next-intl`'s `Locale` type

## Test plan
- [x] `cd app && npm run build`

Made with [Cursor](https://cursor.com)